### PR TITLE
Fix lesson completion + XP transaction

### DIFF
--- a/backend/checkLesson.js
+++ b/backend/checkLesson.js
@@ -1,0 +1,13 @@
+require("dotenv").config();
+const { PrismaClient } = require("@prisma/client");
+
+const p = new PrismaClient();
+
+p.lesson
+  .findUnique({ where: { id: "cmk4g7e100015owd9q5gbs" } })
+  .then((r) => {
+    console.log("FOUND?", !!r);
+    console.log(r);
+  })
+  .catch((e) => console.error(e))
+  .finally(() => p.$disconnect());

--- a/backend/src/controllers/dashboard.controller.ts
+++ b/backend/src/controllers/dashboard.controller.ts
@@ -1,0 +1,104 @@
+import type { Request, Response } from "express";
+import prisma from "../prisma/prisma";
+
+const DEFAULT_LESSON_XP = 10;
+
+const startOfDayUTC = (d: Date) => {
+  const x = new Date(d);
+  x.setUTCHours(0, 0, 0, 0);
+  return x;
+};
+
+export const computeStreakFromDates = (completedAtDates: Date[]) => {
+  if (completedAtDates.length === 0) return 0;
+
+  const daySet = new Set<number>();
+  for (const dt of completedAtDates) daySet.add(startOfDayUTC(dt).getTime());
+
+  const today = startOfDayUTC(new Date()).getTime();
+  const yesterday = today - 24 * 60 * 60 * 1000;
+
+  if (!daySet.has(today) && !daySet.has(yesterday)) return 0;
+
+  let streak = 0;
+  let cursor = daySet.has(today) ? today : yesterday;
+
+  while (daySet.has(cursor)) {
+    streak += 1;
+    cursor -= 24 * 60 * 60 * 1000;
+  }
+
+  return streak;
+};
+
+export const getMyDashboard = async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  const userId = req.user.userId;
+
+  try {
+    const profile = await prisma.profile.findUnique({
+      where: { userId },
+      select: { xp: true },
+    });
+
+    const completedRows = await prisma.lessonProgress.findMany({
+      where: { userId, isCompleted: true, completedAt: { not: null } },
+      select: { completedAt: true },
+      orderBy: { completedAt: "desc" },
+      take: 365,
+    });
+
+    const dates = completedRows
+      .map((r) => r.completedAt)
+      .filter((d): d is Date => d instanceof Date);
+
+    const streak = computeStreakFromDates(dates);
+
+    const enrollments = await prisma.enrollment.findMany({
+      where: { userId, status: "active" },
+      include: {
+        path: {
+          select: { id: true, title: true, category: true, level: true, estMinutes: true },
+        },
+      },
+      orderBy: { startedAt: "desc" },
+      take: 20,
+    });
+
+    const currentPaths = await Promise.all(
+      enrollments.map(async (enr) => {
+        const pathId = enr.pathId;
+
+        const totalLessons = await prisma.lesson.count({
+          where: { module: { pathId } },
+        });
+
+        const completedLessons = await prisma.lessonProgress.count({
+          where: { userId, isCompleted: true, lesson: { module: { pathId } } },
+        });
+
+        const percent = totalLessons === 0 ? 0 : Math.round((completedLessons / totalLessons) * 100);
+
+        return {
+          path: enr.path,
+          startedAt: enr.startedAt,
+          progress: { totalLessons, completedLessons, percent },
+        };
+      })
+    );
+
+    return res.status(200).json({
+      ok: true,
+      xp: profile?.xp ?? 0,
+      streak,
+      currentPaths,
+      lessonXp: DEFAULT_LESSON_XP,
+    });
+  } catch (e) {
+    console.error("getMyDashboard error:", e);
+    return res.status(500).json({ ok: false, error: "INTERNAL_ERROR" });
+  }
+};

--- a/backend/src/controllers/lessonComplete.controller.ts
+++ b/backend/src/controllers/lessonComplete.controller.ts
@@ -1,0 +1,77 @@
+import type { Request, Response } from "express";
+import prisma from "../prisma/prisma";
+
+const DEFAULT_LESSON_XP = 10;
+
+export const completeLesson = async (req: Request, res: Response) => {
+  if (!req.user) {
+    return res.status(401).json({ ok: false, error: "UNAUTHORIZED" });
+  }
+
+  const userId = req.user.userId;
+  const lessonId = req.params.id;
+
+  if (typeof lessonId !== "string" || lessonId.length === 0) {
+    return res.status(400).json({ ok: false, error: "BAD_REQUEST" });
+  }
+
+  try {
+    console.log("DATABASE_URL =", process.env.DATABASE_URL);
+    console.log("DB_URL =", process.env.DB_URL);
+    console.log("lessonId reçu:", lessonId);
+
+    const lesson = await prisma.lesson.findUnique({
+      where: { id: lessonId },
+      select: { id: true },
+    });
+
+    if (!lesson) {
+      return res.status(404).json({ ok: false, error: "LESSON_NOT_FOUND" });
+    }
+
+    const existing = await prisma.lessonProgress.findUnique({
+      where: { userId_lessonId: { userId, lessonId } },
+    });
+
+    if (existing?.isCompleted) {
+      return res.status(200).json({
+        ok: true,
+        completed: true,
+        alreadyCompleted: true,
+      });
+    }
+
+    const now = new Date();
+
+    await prisma.lessonProgress.upsert({
+      where: { userId_lessonId: { userId, lessonId } },
+      update: { isCompleted: true, completedAt: now },
+      create: { userId, lessonId, isCompleted: true, completedAt: now },
+    });
+
+    await prisma.xPTransaction.create({
+      data: {
+        userId,
+        source: "lesson",
+        sourceId: lessonId,
+        points: DEFAULT_LESSON_XP,
+      },
+    });
+
+    await prisma.profile.update({
+      where: { userId },
+      data: { xp: { increment: DEFAULT_LESSON_XP } },
+    });
+
+    return res.status(200).json({
+      ok: true,
+      completed: true,
+      alreadyCompleted: false,
+      addedXp: DEFAULT_LESSON_XP,
+    });
+  } catch (e) {
+    console.error("completeLesson error:", e);
+    return res.status(500).json({ ok: false, error: "INTERNAL_ERROR" });
+  }
+};
+

--- a/backend/src/controllers/progress.controller.ts
+++ b/backend/src/controllers/progress.controller.ts
@@ -1,11 +1,13 @@
 import prisma from "../prisma/prisma";
 
-// temporaire pour live tant que lauth nest pas la
-const getUserId = () => "cmkefe0bs0000j5osvwoeow88";
+
+const TEMP_USER_ID = "cmkefe0bs0000j5osvwoeow88";
+const getUserId = (req: any) => req?.user?.userId ?? TEMP_USER_ID;
+
 
 export const enroll = async (req: any, res: any) => {
   try {
-    const userId = getUserId();
+    const userId = getUserId(req);
     const pathId = req.params.pathId;
 
     await prisma.enrollment.upsert({
@@ -23,7 +25,7 @@ export const enroll = async (req: any, res: any) => {
 
 export const getProgress = async (req: any, res: any) => {
   try {
-    const userId = getUserId();
+    const userId = getUserId(req);
     const pathId = req.params.pathId;
 
     const lessons = await prisma.lesson.findMany({

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,11 +1,9 @@
+import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import userRoutes from "./routes/user.routes";
 import progressRoutes from "./routes/progress.routes";
-import pathRoutes from "./routes/path.routes";
-import catalogRoutes from "./routes/catalog.routes";
-import moduleRoutes from "./routes/module.routes";
-import lessonRoutes from "./routes/lessons.routes";
+import userRoutes from "./routes/user.routes";
 
 const app = express();
 
@@ -27,4 +25,8 @@ app.use("/api/progress", progressRoutes);
 const PORT = 3000;
 app.listen(PORT, () => {
   console.log("Server running on port", PORT);
+
+  app.use(express.json());
+app.use("/api", apiRoutes);
+
 });

--- a/backend/src/routes/api.routes.ts
+++ b/backend/src/routes/api.routes.ts
@@ -1,0 +1,11 @@
+import { Router } from "express";
+import { authenticate } from "../middleware/auth.middleware";
+import { completeLesson } from "../controllers/lessonComplete.controller";
+import { getMyDashboard } from "../controllers/dashboard.controller";
+
+const router = Router();
+
+router.post("/lessons/:id/complete", authenticate, completeLesson);
+router.get("/dashboard/me", authenticate, getMyDashboard);
+
+export default router;


### PR DESCRIPTION
Ajout de la complétion des leçons avec attribution d’XP.

Création de l’endpoint `POST /api/lessons/:id/complete`
Empêche la complétion multiple d’une même leçon
Ajoute l’XP à l’utilisateur via une transaction
Mise à jour du progrès de la leçon

test
Testé avec Thunder Client.


